### PR TITLE
Fixes error when Omnipay\Common\CreditCard is passed to a request

### DIFF
--- a/src/GlobalPayments/Message/AbstractRequest.php
+++ b/src/GlobalPayments/Message/AbstractRequest.php
@@ -25,8 +25,12 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function setCard($value)
     {
-        if ($value && !$value instanceof CreditCard) {
-            $value = new CreditCard($value);
+        if ($value) {
+            if ($value instanceof \Omnipay\Common\CreditCard) {
+                $value = new CreditCard($value->getParameters());
+            } else if (!$value instanceof CreditCard) {
+                $value = new CreditCard($value);
+            }
         }
 
         return $this->setParameter('card', $value);


### PR DESCRIPTION
Currently it is not possible for an instance of `Omnipay\Common\CreditCard` to be passed to a request. This update checks for this case and converts it to `Omnipay\GlobalPayments\CreditCard`.